### PR TITLE
automatic_scalingの設定を金節約側により倒した

### DIFF
--- a/backend/app.yaml
+++ b/backend/app.yaml
@@ -5,6 +5,9 @@ runtime: go
 api_version: go1.9
 instance_class: F1
 automatic_scaling:
+  target_cpu_utilization: 0.75
+  target_throughput_utilization: 0.75
+  max_instances: 5
   min_idle_instances: 0
   max_idle_instances: automatic  # default value
   min_pending_latency: 30ms  # default value


### PR DESCRIPTION
target_cpu_utilization

0.5〜0.95の値を指定します。デフォルトは 0.6です。
このパラメータは、トラフィックを処理する新しいインスタンスを開始するCPU使用率のしきい値を指定します。パフォーマンスとコストのバランスをとり、パフォーマンスの向上とコストの増加、パフォーマンスの低下だけでなくコストの削減を実現します。たとえば、値0.7は、CPU使用率が70％に達した後に新しいインスタンスが開始されることを意味します。

target_throughput_utilization

0.5〜0.95の値を指定します。デフォルトは 0.6です。
max_concurrent_requests同時リクエストのために新しいインスタンスがいつ開始されるかを指定するために使用されます。同時要求の数がmax_concurrent_requests時間 target_throughput_utilizationに等しい値に達する と、スケジューラは新しいインスタンスを開始します。

max_instances

0〜2147483647の値を指定します。ゼロは設定を無効にします。
このパラメータは、App Engineがこのモジュールバージョンに対して作成するインスタンスの最大数を指定します。これは、モジュールのコストを制限するのに便利です。

Close #34