### PR TITLE
connpass event取得を支部ごとにTQでやるようにした

### DIFF
--- a/backend/connpass_api.go
+++ b/backend/connpass_api.go
@@ -84,7 +84,8 @@ func (api *ConnpassAPI) HandlerCron(ctx context.Context) error {
 	tl := []*taskqueue.Task{}
 	for k, _ := range m {
 		tl = append(tl, &taskqueue.Task{
-			Path: fmt.Sprintf("/api/queue/1/connpass/%v", k),
+			Path:   fmt.Sprintf("/api/queue/1/connpass/%v", k),
+			Method: http.MethodGet,
 		})
 	}
 	_, err := taskqueue.AddMulti(ctx, tl, "connpass")

--- a/queue.yaml
+++ b/queue.yaml
@@ -1,0 +1,3 @@
+queue:
+- name: connpass
+  rate: 1/m

--- a/queue.yaml
+++ b/queue.yaml
@@ -1,3 +1,8 @@
 queue:
 - name: connpass
+  bucket_size: 1
   rate: 1/m
+  max_concurrent_requests: 1
+  retry_parameters:
+    task_retry_limit: 3
+    min_backoff_seconds: 60


### PR DESCRIPTION
支部が増えて、イベントが増えた結果、一度に取得するのが難しくなったため。

Close #56